### PR TITLE
Renamed senders of #size: to #extent:

### DIFF
--- a/src/BlocBenchs-Alexandrie/AeBenchBlurConvexPolygonRunner.class.st
+++ b/src/BlocBenchs-Alexandrie/AeBenchBlurConvexPolygonRunner.class.st
@@ -65,7 +65,7 @@ AeBenchBlurConvexPolygonRunner class >> exampleInteractive [
 	draggableVertexElements :=
 		vertices withIndexCollect: [ :eachPoint :index |
 			BlElement new
-				size: cornerExtent;
+				extent: cornerExtent;
 				position: eachPoint - (cornerExtent / 2);
 				geometry: BlCircleGeometry new;
 				addEventHandler: BlPullHandler new;

--- a/src/BlocBenchs-Benchs/BlBAbstractCircleCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBAbstractCircleCase.class.st
@@ -15,7 +15,7 @@ BlBAbstractCircleCase >> newFigureWith: random [
 
 	^ BlElement new
 		geometry: BlCircleGeometry new;
-		size: self radius * 2;
+		extent: self radius * 2;
 		in:[ :me | self prepare: me with: random ];
 		yourself
 

--- a/src/BlocBenchs-Benchs/BlBAbstractSimpleAnimationCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBAbstractSimpleAnimationCase.class.st
@@ -18,7 +18,7 @@ BlBAbstractSimpleAnimationCase >> newElement [
 
 	^ BlElement new
 		position: 100 asPoint;
-		size: 100 asPoint;
+		extent: 100 asPoint;
 		border: (BlBorder paint: Color gray width: 4);
 		addAnimation: (self newSteppingAnimation);
 		yourself

--- a/src/BlocBenchs-Benchs/BlBAbstractTranslatingFiguresCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBAbstractTranslatingFiguresCase.class.st
@@ -47,7 +47,7 @@ BlBAbstractTranslatingFiguresCase >> newElementWithIndependentAnimations [
 	| random container |
 	random := self newRandom.
 	container := BlElement new
-		size: self spaceExtent;
+		extent: self spaceExtent;
 		yourself.
 
 	1 to: self numberOfFigures do: [ :index |
@@ -69,7 +69,7 @@ BlBAbstractTranslatingFiguresCase >> newElementWithSingleAnimation [
 	| random container |
 	random := self newRandom.
 	container := BlElement new
-		size: self spaceExtent;
+		extent: self spaceExtent;
 		addAnimation: ((BlTransformAnimation translate: self targetTranslation)
 		  duration: self duration;
 		  yourself);

--- a/src/BlocBenchs-Benchs/BlBAnnulusSectorCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBAnnulusSectorCase.class.st
@@ -15,6 +15,6 @@ BlBAnnulusSectorCase >> newFigureWith: random [
 				   innerRadius: (random nextBetween: 0.0 and: 0.4);
 				   outerRadius: (random nextBetween: 0.5 and: 1.0);
 				   yourself);
-		  size: 100 asPoint;
+		  extent: 100 asPoint;
 		  yourself
 ]

--- a/src/BlocBenchs-Benchs/BlBBoxWindmillBlocCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBBoxWindmillBlocCase.class.st
@@ -14,14 +14,14 @@ BlBBoxWindmillBlocCase >> newElement [
 
 	aContainerElement := BlElement new
 		clipChildren: false;
-		size: self logicalExtent;
+		extent: self logicalExtent;
 		background: self backgroundColor;
 		yourself.
 
 	boxElements := self boxPositions collect: [ :eachPoint | 
 		BlElement new
 			outskirts: BlOutskirts centered;
-			size: self boxExtent;
+			extent: self boxExtent;
 			background: self boxColor;
 			position: eachPoint;
 			border: (BlBorder

--- a/src/BlocBenchs-Benchs/BlBClippedImagesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBClippedImagesCase.class.st
@@ -13,7 +13,7 @@ BlBClippedImagesCase >> newImageElementWith: random [
 	^ BlElement new
 		clipChildren: true;
 		geometry: BlRectangleGeometry new;
-		size: randomIcon extent // 2;
+		extent: randomIcon extent // 2;
 		background: randomIcon;
 		yourself
 

--- a/src/BlocBenchs-Benchs/BlBCompositionCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBCompositionCase.class.st
@@ -29,7 +29,7 @@ BlBCompositionCase >> newElement [
 
 	container :=
 		BlElement new
-			size: self logicalExtent;
+			extent: self logicalExtent;
 			addAnimation: (BlBasicAnimation new
 				onStepDo: [ :target | target background: backgroundColorGenerator next ];
 				yourself);
@@ -38,7 +38,7 @@ BlBCompositionCase >> newElement [
 	"static"
 	staticComplexElement := BlElement new
 		background: Color transparent;
-		size: self layerExtent;
+		extent: self layerExtent;
 		yourself.
 	1 to: self numberOfFigures do: [ :index |
 		staticComplexElement addChild: (self newFigure: random) ].
@@ -56,7 +56,7 @@ BlBCompositionCase >> newFigure: random [
 	^ BlElement new
 		background: (Color random: random);
 		position: (self nextLocation: random);
-		size: self figureExtent;
+		extent: self figureExtent;
 		yourself
 ]
 

--- a/src/BlocBenchs-Benchs/BlBHighlightOnMouseMoveProfileCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBHighlightOnMouseMoveProfileCase.class.st
@@ -31,7 +31,7 @@ BlBHighlightOnMouseMoveProfileCase >> newElement [
 				position: (Point
 					x: cellExtent x * (col-1)
 					y: cellExtent y * (row-1));
-				size: cellExtent + 1;
+				extent: cellExtent + 1;
 				background: Color random darker;
 				clipChildren: false;
 				addEventHandlerOn: BlMouseMoveEvent
@@ -47,7 +47,7 @@ BlBHighlightOnMouseMoveProfileCase >> newElement [
 		addAnimation: self newSteppingAnimation;
 		addChildren: board asArray;
 		clipChildren: false;
-		size: boardExtent;
+		extent: boardExtent;
 		yourself
 ]
 

--- a/src/BlocBenchs-Benchs/BlBNestedTransformationsCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBNestedTransformationsCase.class.st
@@ -40,7 +40,7 @@ BlBNestedTransformationsCase >> newElement [
 		BlElement new
 			clipChildren: false;
 			background: (Color random: random);
-			size: self figureExtent;
+			extent: self figureExtent;
 			addAnimation: anAnimation;
 			yourself ].
 

--- a/src/BlocBenchs-Benchs/BlBOutskirtsBenchCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBOutskirtsBenchCase.class.st
@@ -85,7 +85,7 @@ BlBOutskirtsBenchCase >> newChildWith: random [
 	^ BlElement new
 		  geometry: BlRectangleGeometry new;
 		  background: (Color gray alpha: 0.5);
-		  size: self figureExtent / 2;
+		  extent: self figureExtent / 2;
 		  yourself
 ]
 
@@ -117,7 +117,7 @@ BlBOutskirtsBenchCase >> newFigureWith: random [
 		  background: self backgroundColor;
 		  outskirts: self outskirts;
 		  geometry: self newFigureGeometry;
-		  size: self figureExtent;
+		  extent: self figureExtent;
 		  clipChildren: self mustClipChildren;
 		  addChild: (self newChildWith: random);
 		  yourself

--- a/src/BlocBenchs-Benchs/BlBRotatedImagesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBRotatedImagesCase.class.st
@@ -12,7 +12,7 @@ BlBRotatedImagesCase >> newImageElementWith: random [
 	
 	^ BlElement new
 		transformDo: [ :t | t rotateBy: (self angleInDegreesWith: random) ];
-		size: randomIcon extent;
+		extent: randomIcon extent;
 		background: randomIcon;
 		yourself
 ]

--- a/src/BlocBenchs-Benchs/BlBRotatedRectanglesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBRotatedRectanglesCase.class.st
@@ -16,7 +16,7 @@ BlBRotatedRectanglesCase >> newFigureWith: random [
 	^ BlElement new
 		  background: (Color random: random);
 		  geometry: BlRectangleGeometry new;
-		  size: self figureExtent;
+		  extent: self figureExtent;
 		  transformDo: [ :t | t rotateBy: (self angleInDegreesWith: random) ];
 		  yourself
 ]

--- a/src/BlocBenchs-Benchs/BlBScaledRectanglesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBScaledRectanglesCase.class.st
@@ -15,7 +15,7 @@ BlBScaledRectanglesCase >> newFigureWith: random [
 
 	^ BlElement new
 		  geometry: BlRectangleGeometry new;
-		  size: self figureExtent;
+		  extent: self figureExtent;
 		  transformDo: [ :aBuilder | aBuilder scaleBy: self scale ];
 		  background: (Color random: random);
 		  yourself

--- a/src/BlocBenchs-Benchs/BlBSolidImagesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBSolidImagesCase.class.st
@@ -11,7 +11,7 @@ BlBSolidImagesCase >> newImageElementWith: random [
 	randomIcon := self newFormWith: random.
 	
 	^ BlElement new
-	  size: randomIcon extent;
+	  extent: randomIcon extent;
 	  background: randomIcon;
 	  yourself
 ]

--- a/src/BlocBenchs-Benchs/BlBTranslucentEllipsesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBTranslucentEllipsesCase.class.st
@@ -20,6 +20,6 @@ BlBTranslucentEllipsesCase >> newFigureWith: random [
 				paint: ((Color random: random) alpha: 0.8)
 				width: 10);
 		  geometry: BlEllipseGeometry new;
-		  size: (self figureExtent: random);
+		  extent: (self figureExtent: random);
 		  yourself
 ]

--- a/src/BlocBenchs-Benchs/BlBTranslucentImagesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlBTranslucentImagesCase.class.st
@@ -11,7 +11,7 @@ BlBTranslucentImagesCase >> newImageElementWith: random [
 	randomIcon := self newFormWith: random.
 	
 	^ BlElement new
-	  size: randomIcon extent;
+	  extent: randomIcon extent;
 	  background: (randomIcon asBlBackground opacity: 0.5; yourself);
 	  yourself
 ]

--- a/src/BlocBenchs-Benchs/BlRoundedRectanglesCase.class.st
+++ b/src/BlocBenchs-Benchs/BlRoundedRectanglesCase.class.st
@@ -16,6 +16,6 @@ BlRoundedRectanglesCase >> newFigureWith: random [
 	^ BlElement new
 		  background: (Color random: random);
 		  geometry: (BlRoundedRectangleGeometry cornerRadius: 20);
-		  size: self figureExtent;
+		  extent: self figureExtent;
 		  yourself
 ]

--- a/src/BlocBenchs-FPS/PCPolylineBenchCase.class.st
+++ b/src/BlocBenchs-FPS/PCPolylineBenchCase.class.st
@@ -15,7 +15,7 @@ PCPolylineBenchCase >> newFigureWith: random [
 
 	^ BlElement new
 		  geometry: (BlPolylineGeometry vertices: self vertices);
-		  size: (Rectangle encompassing: self vertices) extent;
+		  extent: (Rectangle encompassing: self vertices) extent;
 		  border: (BlBorder paint: (Color random: random) width: self borderWidth);
 		  background: Color transparent;
 		  yourself

--- a/src/BlocBenchs-Old/BlMouseMoveBenchmark.class.st
+++ b/src/BlocBenchs-Old/BlMouseMoveBenchmark.class.st
@@ -197,7 +197,7 @@ BlMouseMoveBenchmark >> runFor: aGeometry addingResultsOn: aDataFrame [
 	elements := (1 to: nestingLevel) collect: [ :index |
 		            BlElement new
 			            position: 0 @ 0;
-			            size: extent;
+			            extent: extent;
 			            geometry: aGeometry;
 			            background: (Color random: random);
 			            addEventHandlerOn: BlMouseMoveEvent


### PR DESCRIPTION
See https://github.com/pharo-graphics/Bloc/issues/802

Manually picked, one by one, using the following scope:

```
ourPackages := PackageOrganizer default packages
		  select: [ :package | package name beginsWithAnyOf: #(Bloc Toplo Album) ].
scope := ScopesManager newScopeFrom: ourPackages.
scope label: 'Bloc ecosystem'.
ScopesManager addScope: scope.
```